### PR TITLE
Remove pytz

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,5 @@ hurry.filesize
 Jinja2
 MarkupSafe
 python-dateutil
-pytz
 sqlparse
 xlwt==1.3.0


### PR DESCRIPTION
- Remove unused and [deprecated](https://docs.djangoproject.com/en/5.0/releases/4.0/#zoneinfo-default-timezone-implementation) pytz from django-handyhelpers.

---
https://github.com/search?q=repo%3Adavidslusser%2Fdjango-handyhelpers%20pytz&type=code it only shows up in `requirements.txt`